### PR TITLE
V0.2.9 lineage v2

### DIFF
--- a/src/execution/lineage_manager.cpp
+++ b/src/execution/lineage_manager.cpp
@@ -163,6 +163,7 @@ void ManageLineage::CreateLineageTables(PhysicalOperator *op) {
     catalog.CreateTable(context, bound_create_info.get());
     break;
   }
+  case PhysicalOperatorType::PERFECT_HASH_GROUP_BY:
   case PhysicalOperatorType::HASH_GROUP_BY: {
     // CREATE TABLE base_out (group_id INTEGER, out_index INTEGER, out_chunk_id INTEGER)
     auto info = make_unique<CreateTableInfo>();
@@ -340,6 +341,7 @@ void ManageLineage::Persist(PhysicalOperator *op, shared_ptr<LineageContext> lin
 
     break;
   }
+  case PhysicalOperatorType::PERFECT_HASH_GROUP_BY:
   case PhysicalOperatorType::HASH_GROUP_BY: {
     if (is_sink) {
       std::shared_ptr<LineageOpUnary> sink_lop = std::dynamic_pointer_cast<LineageOpUnary>(lineage->GetLineageOp(op->id, 1));

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -95,6 +95,13 @@ void PhysicalLimit::GetChunkInternal(ExecutionContext &context, DataChunk &chunk
 
 		state->current_offset += state->child_chunk.size();
 	} while (chunk.size() == 0);
+
+#ifdef LINEAGE
+    context.lineage->RegisterDataPerOp(
+        id,
+        make_shared<LineageOpUnary>(make_shared<LineageRange>(offset, limit))
+    );
+#endif
 }
 
 unique_ptr<PhysicalOperatorState> PhysicalLimit::GetOperatorState() {

--- a/src/include/duckdb/execution/lineage_context.hpp
+++ b/src/include/duckdb/execution/lineage_context.hpp
@@ -96,6 +96,10 @@ public:
     std::cout << std::endl;
   }
 
+  idx_t getAtIndex(idx_t idx) {
+    return (idx_t)vec[idx];
+  }
+
   unsigned long size_bytes() {
     return count * sizeof(vec[0]);
   }

--- a/src/include/duckdb/execution/perfect_aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/perfect_aggregate_hashtable.hpp
@@ -27,7 +27,13 @@ public:
 	void Combine(PerfectAggregateHashTable &other);
 
 	//! Scan the HT starting from the scan_position
+#ifdef LINEAGE
+	void Scan(ExecutionContext &context, idx_t &scan_position, DataChunk &result);
+	// Used to map input to groups
+	shared_ptr<LineageOpUnary> sink_per_chunk_lineage;
+#else
 	void Scan(idx_t &scan_position, DataChunk &result);
+#endif
 
 protected:
 	Vector addresses;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -288,7 +288,7 @@ void RowGroup::TemplatedScan(Transaction *transaction, RowGroupScanState &state,
 	auto &column_ids = state.parent.column_ids;
 	auto &adaptive_filter = state.parent.adaptive_filter;
 #ifdef LINEAGE
-  transaction->scan_lineage_data = make_unique<LineageCollection>();
+  if (transaction) transaction->scan_lineage_data = make_unique<LineageCollection>();
 #endif
 	while (true) {
 		if (state.vector_index * STANDARD_VECTOR_SIZE >= state.max_row) {
@@ -421,11 +421,13 @@ void RowGroup::TemplatedScan(Transaction *transaction, RowGroupScanState &state,
 			count = approved_tuple_count;
 
 #ifdef LINEAGE
-		  transaction->scan_lineage_data->add("filter", make_unique<LineageSelVec>(move(sel), approved_tuple_count));
+      if (transaction)
+		    transaction->scan_lineage_data->add("filter", make_unique<LineageSelVec>(move(sel), approved_tuple_count));
 #endif
 		}
 #ifdef LINEAGE
-    transaction->scan_lineage_data->add("vector_index", make_unique<LineageConstant>(state.vector_index));
+    if (transaction)
+      transaction->scan_lineage_data->add("vector_index", make_unique<LineageConstant>(state.vector_index));
 #endif
 		result.SetCardinality(count);
 		state.vector_index++;

--- a/test/sql/lineage/groupby_perfect_hash_aggregate_lineage/test_groupby_perfect_hash_aggregate_lineage.test
+++ b/test/sql/lineage/groupby_perfect_hash_aggregate_lineage/test_groupby_perfect_hash_aggregate_lineage.test
@@ -1,0 +1,82 @@
+# name: test/sql/lineage/groupby_lineage/test_groupby_perfect_hash_aggregate_lineage.test
+# description: Test Group By lineage -- perfect hash aggregate
+# group: [groupby_perfect_hash_aggregate_lineage]
+#
+#┌───────────────────────────┐
+#│   PERFECT_HASH_GROUP_BY   │
+#│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+#│             #0            │
+#│          avg(#1)          │
+#└─────────────┬─────────────┘
+#┌─────────────┴─────────────┐
+#│         PROJECTION        │
+#│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+#│             i             │
+#│             j             │
+#└─────────────┬─────────────┘
+#┌─────────────┴─────────────┐
+#│          SEQ_SCAN         │
+#│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+#│             t1            │
+#│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+#│             i             │
+#│             j             │
+#└───────────────────────────┘
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+statement ok
+CREATE TABLE t1(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO t1 VALUES (1, 2),  (5, 2), (1, 4), (2, 1), (1, 3),(2, 2), (4, 1), (5, 1)
+
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+# standalone limit
+query II
+select t1.i, avg(t1.j) from t1 GROUP BY t1.i
+----
+1	3.000000
+2	1.500000
+4	1.000000
+5	1.500000
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+
+query III
+select group_id, out_index, out_chunk_id from PERFECT_HASH_GROUP_BY_9_0_PROBE;
+----
+1	0	0
+2	1	0
+4	2	0
+5	3	0
+
+query III
+select group_id, in_index, out_chunk_id from PERFECT_HASH_GROUP_BY_9_0_SINK;
+----
+1	0	0
+5	1	0
+1	2	0
+2	3	0
+1	4	0
+2	5	0
+4	6	0
+5	7	0
+
+query IIII
+select s.out_chunk_id, s.in_index as input, p.out_chunk_id, p.out_index as output from PERFECT_HASH_GROUP_BY_9_0_PROBE as p, PERFECT_HASH_GROUP_BY_9_0_SINK as s where p.out_chunk_id=s.out_chunk_id and p.group_id=s.group_id;
+----
+0	0	0	0
+0	1	0	3
+0	2	0	0
+0	3	0	1
+0	4	0	0
+0	5	0	1
+0	6	0	2
+0	7	0	3

--- a/test/sql/lineage/index_join/test_index_join_lineage.test
+++ b/test/sql/lineage/index_join/test_index_join_lineage.test
@@ -1,0 +1,59 @@
+# name: test/sql/index/join_lineage/test_index_join_lineage.test
+# description: Test Joins using art indexes
+# group: [index_join]
+
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+PRAGMA force_index_join
+
+statement ok
+CREATE TABLE t1(i INTEGER, j INTEGER);
+CREATE TABLE t2(i INTEGER);
+CREATE INDEX i_index ON t1 using art(i);
+
+statement ok
+INSERT INTO t1 SELECT i+1, i FROM range(0,60) tbl(i);
+INSERT INTO t2 SELECT i+1 FROM range(50,60) tbl(i);
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+# standalone limit
+query III
+select t1.i, t1.j, t2.i from t1 inner join t2 on (t1.i = t2.i)
+----
+51	50	51
+52	51	52
+53	52	53
+54	53	54
+55	54	55
+56	55	56
+57	56	57
+58	57	58
+59	58	59
+60	59	60
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+query II
+SELECT * FROM queries_list;
+----
+17	select t1.i, t1.j, t2.i from t1 inner join t2 on (t1.i = t2.i)
+19	PRAGMA trace_lineage = "OFF";
+
+query IIIII
+select rowid, out_chunk_id, in_index, lhs_value, rhs_value from INDEX_JOIN_17_1;
+----
+0	0	0	0	50
+1	0	1	1	51
+2	0	2	2	52
+3	0	3	3	53
+4	0	4	4	54
+5	0	5	5	55
+6	0	6	6	56
+7	0	7	7	57
+8	0	8	8	58
+9	0	9	9	59
+

--- a/test/sql/lineage/limit_lineage/test_limit_lineage.test
+++ b/test/sql/lineage/limit_lineage/test_limit_lineage.test
@@ -1,0 +1,38 @@
+# name: test/sql/lineage/limit_lineage/test_limit_lineage.test
+# description: Test Limit Lineage
+# group: [limit_lineage]
+
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+statement ok
+CREATE TABLE t1(i INTEGER);
+
+statement ok
+INSERT INTO t1 SELECT i FROM range(0,5) tbl(i);
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+query I
+select * from t1 limit 3 offset 1
+----
+1
+2
+3
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+query II
+SELECT * FROM queries_list;
+----
+9	select * from t1 limit 3 offset 1
+11	PRAGMA trace_lineage = "OFF";
+
+
+query IIII
+select rowid, * from LIMIT_9_0
+----
+0	1	3	0


### PR DESCRIPTION
Track lineage for Index join, limit, and perfect hash aggregate. Check if transaction is allocated during table scan before using it for lineage.  V2: avoid copying op in perfect hash egg.