### PR TITLE
Fix build without LINEAGE macro and an issue with index join

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -153,7 +153,7 @@ void PhysicalHashJoin::Sink(ExecutionContext &context, GlobalOperatorState &stat
 #ifdef LINEAGE
 		sink.hash_table->Build(context, lstate.join_keys, input);
 #else
-		sink.hash_table->Build(lstate.join_keys, lstate.build_chunk);
+		sink.hash_table->Build(lstate.join_keys, input);
 #endif
 	} else {
 		// there are only keys: place an empty chunk in the payload

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -113,7 +113,11 @@ void PhysicalTableScan::GetChunkInternal(ExecutionContext &context, DataChunk &c
 }
 
 string PhysicalTableScan::GetName() const {
+#ifdef LINEAGE
 	return StringUtil::Upper(function.name) + "_" + std::to_string(id);
+#else
+	return StringUtil::Upper(function.name);
+#endif
 }
 
 string PhysicalTableScan::ParamsToString() const {

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -10,7 +10,11 @@
 namespace duckdb {
 
 string PhysicalOperator::GetName() const {
+#ifdef LINEAGE
 	return PhysicalOperatorToString(type) + "_" + std::to_string(id);
+#else
+	return PhysicalOperatorToString(type);
+#endif
 }
 
 string PhysicalOperator::ToString() const {

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -63,9 +63,11 @@ void StreamQueryResult::Close() {
 		return;
 	}
 	is_open = false;
+#ifdef LINEAGE
 	if (context->trace_lineage) {
 		context->lineage_manager->CreateLineageTables(prepared->plan.get());
 	}
+#endif
 	context->Cleanup();
 }
 

--- a/test/sql/lineage/index_join/test_index_join_lineage.test
+++ b/test/sql/lineage/index_join/test_index_join_lineage.test
@@ -57,3 +57,39 @@ select rowid, lhs_index, rhs_index, out_index from LINEAGE_1_INDEX_JOIN_2_0;
 8	8	58	8
 9	9	59	9
 
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+# standalone limit
+query II
+select t1.i, t2.i from t1 inner join t2 on (t1.i = t2.i)
+----
+51	51
+52	52
+53	53
+54	54
+55	55
+56	56
+57	57
+58	58
+59	59
+60	60
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+query IIII
+select rowid, lhs_index, rhs_index, out_index from LINEAGE_3_INDEX_JOIN_2_0;
+----
+0	0	50	0
+1	1	51	1
+2	2	52	2
+3	3	53	3
+4	4	54	4
+5	5	55	5
+6	6	56	6
+7	7	57	7
+8	8	58	8
+9	9	59	9
+


### PR DESCRIPTION
Add missing LINEAGE macros and fix issues when LINEAGE is disabled.
collect rowids for index join when a table scan is not required. 