### PR TITLE
Add queries_list relation as a system table

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -28,12 +28,6 @@
 
 namespace duckdb {
 
-#ifdef LINEAGE
-void  TableCatalogEntry::Persist(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
-    storage->Append(table, context, chunk);
-}
-#endif
-
 idx_t TableCatalogEntry::GetColumnIndex(string &column_name, bool if_exists) {
 	auto entry = name_map.find(column_name);
 	if (entry == name_map.end()) {

--- a/src/execution/lineage/lineage_manager.cpp
+++ b/src/execution/lineage/lineage_manager.cpp
@@ -176,5 +176,14 @@ void LineageManager::InitOperatorPlan(PhysicalOperator *op) {
 	CreateOperatorLineage(op, -1, trace_lineage, true); // Always index root
 }
 
+void LineageManager::StoreQueryLineage(std::unique_ptr<PhysicalOperator> op, string query) {
+	if (!trace_lineage) return;
+	// id of a query is their offset in query_to_id vector
+	idx_t query_id = query_to_id.size();
+	query_to_id.push_back(query);
+	CreateLineageTables(op.get(), query_id);
+	queryid_to_plan[query_id] = move(op);
+}
+
 } // namespace duckdb
 #endif

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   duckdb_table_func_system
   OBJECT
+  duckdb_queries_list.cpp
   duckdb_columns.cpp
   duckdb_constraints.cpp
   duckdb_dependencies.cpp

--- a/src/function/table/system/duckdb_queries_list.cpp
+++ b/src/function/table/system/duckdb_queries_list.cpp
@@ -1,0 +1,69 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+struct DuckDBQueriesListData : public FunctionOperatorData {
+	DuckDBQueriesListData() : offset(0) {
+	}
+
+	idx_t offset;
+};
+
+//! Create table to store executed queries with their IDs
+//! Table name: duckdb_queries_list()
+//! Schema: (INT query_id, VARCHAR query)
+static unique_ptr<FunctionData> DuckDBQueriesListBind(ClientContext &context, vector<Value> &inputs,
+                                                      unordered_map<string, Value> &named_parameters,
+                                                      vector<LogicalType> &input_table_types,
+                                                      vector<string> &input_table_names,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("query_id");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("query");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<FunctionOperatorData> DuckDBQueriesListInit(ClientContext &context, const FunctionData *bind_data,
+                                                       const vector<column_t> &column_ids, TableFilterCollection *filters) {
+	auto result = make_unique<DuckDBQueriesListData>();
+	return std::move(result);
+}
+
+void DuckDBQueriesListFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
+                               DataChunk *input, DataChunk &output) {
+	auto &data = (DuckDBQueriesListData &)*operator_state;
+	auto queryid_to_plan = context.lineage_manager->query_to_id;
+	if (data.offset >= queryid_to_plan.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < queryid_to_plan.size() && count < STANDARD_VECTOR_SIZE) {
+		string query = queryid_to_plan[data.offset];
+		idx_t col = 0;
+		// query_id, INT
+		output.SetValue(col++, count,Value::INTEGER(data.offset));
+		// query, VARCHAR
+		output.SetValue(col++, count, query);
+
+		count++;
+		data.offset++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBQueriesListFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_queries_list", {}, DuckDBQueriesListFunction, DuckDBQueriesListBind, DuckDBQueriesListInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -28,6 +28,9 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBTablesFun::RegisterFunction(*this);
 	DuckDBTypesFun::RegisterFunction(*this);
 	DuckDBViewsFun::RegisterFunction(*this);
+#ifdef LINEAGE
+	DuckDBQueriesListFun::RegisterFunction(*this);
+#endif
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -51,9 +51,6 @@ public:
 	case_insensitive_map_t<column_t> name_map;
 
 public:
-#ifdef LINEAGE
-	void Persist(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk);
-#endif
 	unique_ptr<CatalogEntry> AlterEntry(ClientContext &context, AlterInfo *info) override;
 	//! Returns whether or not a column with the given name exists
 	bool ColumnExists(const string &name);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -84,4 +84,10 @@ struct DuckDBViewsFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+#ifdef LINEAGE
+struct DuckDBQueriesListFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+#endif
+
 } // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -68,10 +68,6 @@ void StorageManager::Initialize() {
 		// initialize default functions
 		BuiltinFunctions builtin(*con.context, catalog);
 		builtin.Initialize();
-#ifdef LINEAGE
-		// Create query table for later lineage query referencing
-		con.context->lineage_manager->CreateQueryTable();
-#endif
 	}
 
 	// commit transactions

--- a/test/sql/lineage_v2/queries_list/test_queries_list.test
+++ b/test/sql/lineage_v2/queries_list/test_queries_list.test
@@ -1,0 +1,108 @@
+# name: test/sql/lineage_v2/queries_list/test_queries_list.test
+# description: Test Queries List table
+# group: [queries_list]
+
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+query II
+select * from duckdb_queries_list()
+----
+
+statement ok
+CREATE TABLE t1(i INTEGER);
+
+statement ok
+INSERT INTO t1 SELECT i FROM range(0,2000) tbl(i);
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+statement ok
+select * from t1 where 2 > i  OR i > 1998
+
+statement ok
+select * from t1 where i > 2000 OR i > 1998
+
+statement ok
+select * from t1 where i < 2000 OR i > 1998
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+
+query II
+select * from duckdb_queries_list()
+----
+0	PRAGMA trace_lineage = "ON";
+1	select * from t1 where 2 > i  OR i > 1998
+2	select * from t1 where i > 2000 OR i > 1998
+3	select * from t1 where i < 2000 OR i > 1998
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_1_SEQ_SCAN_0_0 WHERE in_index!=out_index OR in_index!=rowid
+----
+
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_2_SEQ_SCAN_0_0 WHERE in_index!=out_index OR in_index!=rowid
+----
+
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_3_SEQ_SCAN_0_0 WHERE in_index!=out_index OR in_index!=rowid
+----
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_1_FILTER_1_0
+----
+0	0	0
+1	1	1
+2	2	1999
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_2_FILTER_1_0
+----
+0	0	1999
+
+query III
+SELECT rowid, out_index, in_index FROM LINEAGE_3_FILTER_1_0 where out_index!=in_index and out_index!=rowid
+----
+
+
+query II
+select * from duckdb_queries_list()
+----
+0	PRAGMA trace_lineage = "ON";
+1	select * from t1 where 2 > i  OR i > 1998
+2	select * from t1 where i > 2000 OR i > 1998
+3	select * from t1 where i < 2000 OR i > 1998
+
+
+statement ok
+PRAGMA trace_lineage = "ON";
+
+statement ok
+select * from t1 where 2 > i  OR i > 1998
+
+statement ok
+select * from t1 where i > 2000 OR i > 1998
+
+statement ok
+select * from t1 where i < 2000 OR i > 1998
+
+statement ok
+PRAGMA trace_lineage = "OFF";
+
+query II
+select * from duckdb_queries_list()
+----
+0	PRAGMA trace_lineage = "ON";
+1	select * from t1 where 2 > i  OR i > 1998
+2	select * from t1 where i > 2000 OR i > 1998
+3	select * from t1 where i < 2000 OR i > 1998
+4	PRAGMA trace_lineage = "ON";
+5	select * from t1 where 2 > i  OR i > 1998
+6	select * from t1 where i > 2000 OR i > 1998
+7	select * from t1 where i < 2000 OR i > 1998


### PR DESCRIPTION
Register and access queries_list relation as a system table instead of creating a queries_list table. 
Problems with the old approach: using existing database could lead to duplicate queries_list registration error.